### PR TITLE
Tiny fix for names of slurm scripts

### DIFF
--- a/oxkat/generate_jobs.py
+++ b/oxkat/generate_jobs.py
@@ -85,7 +85,7 @@ def get_code(myms):
 
     # Last three digits of the data set ID
 
-    myms = myms.split('/')[-1]
+    myms = os.path.split(myms)[-1]
     code = myms.split('_')[0][-3:]
     code = code.replace('-','_')
     return code

--- a/oxkat/generate_jobs.py
+++ b/oxkat/generate_jobs.py
@@ -84,9 +84,9 @@ def timenow():
 def get_code(myms):
 
     # Last three digits of the data set ID
-
+    # But need to avoid .ms for short ms names (slurm does not like extra .)
     myms = os.path.split(myms)[-1]
-    code = myms.split('_')[0][-3:]
+    code = myms.split(".ms")[0][-3:]
     code = code.replace('-','_')
     return code
 


### PR DESCRIPTION
Hi Ian,

Some of Precious's measurement sets have short file names, so the slurm scripts ended up with *.ms.sh in the file names - our slurm isn't happy with those. This fixes that, and shouldn't impact anywhere else so far as I know.